### PR TITLE
Basic QA tools - php-cs-fixer and phpstan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ bin/
 !bin/symfony_requirements
 
 /.env
+/.php_cs.cache

--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,9 @@ run_local:  ## Run local environment
 	docker-compose up -d
 
 lint: ## Run qa checks
-	docker run -it --rm -v $(PWD):/app -w /app jakzal/phpqa:alpine php-cs-fixer fix --dry-run --diff src
+	docker run -it --rm -v $(PWD):/app -w /app jakzal/phpqa:alpine php-cs-fixer fix --rules=@Symfony --dry-run --diff src
 	docker run -it --rm -v $(PWD):/app -w /app jakzal/phpqa:alpine phpstan --level=7 analyse src
+	docker run -it --rm -v $(PWD):/app -w /app jakzal/phpqa:alpine phpmd src text cleancode,codesize,design,unusedcode
 
 codestyle-fix:
 	docker run -it --rm -v $(PWD):/app -w /app jakzal/phpqa:alpine php-cs-fixer fix src

--- a/Makefile
+++ b/Makefile
@@ -13,3 +13,10 @@ test: ## Run tests
 
 run_local:  ## Run local environment
 	docker-compose up -d
+
+lint: ## Run qa checks
+	docker run -it --rm -v $(PWD):/app -w /app jakzal/phpqa:alpine php-cs-fixer fix --dry-run --diff src
+	docker run -it --rm -v $(PWD):/app -w /app jakzal/phpqa:alpine phpstan --level=7 analyse src
+
+codestyle-fix:
+	docker run -it --rm -v $(PWD):/app -w /app jakzal/phpqa:alpine php-cs-fixer fix src


### PR DESCRIPTION
To not overthink installation process (composer deps vs phars) I used `jakzal/phpqa:alpine` image and added `php-cs-fixer` and `phpstan` to lint target. These two are usually sufficient.

What do you think?

Related to #8 