### PR TITLE
Replace host composer installation with one from docker image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ help:
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST) | sort
 
 build: ## Build project
-	composer install
+	docker-compose exec -T php-fpm composer install
 
 test: ## Run tests
 	bin/phpspec run

--- a/docker/php-fpm/Dockerfile
+++ b/docker/php-fpm/Dockerfile
@@ -4,6 +4,13 @@ RUN docker-php-ext-install \
     pdo \
     pdo_mysql
 
+# Install composer
+RUN curl -o /tmp/composer-setup.php https://getcomposer.org/installer \
+  && curl -o /tmp/composer-setup.sig https://composer.github.io/installer.sig \
+  && php -r "if (hash('SHA384', file_get_contents('/tmp/composer-setup.php')) !== trim(file_get_contents('/tmp/composer-setup.sig'))) { unlink('/tmp/composer-setup.php'); echo 'Invalid installer' . PHP_EOL; exit(1); }" \
+  && php /tmp/composer-setup.php --no-ansi --install-dir=/usr/local/bin --filename=composer \
+  && rm -rf /tmp/composer-setup.php
+
 RUN usermod -u 1000 www-data
 
 WORKDIR /var/www/realworld


### PR DESCRIPTION
Now composer is run from host, so everybody needs local php installation with all required extensions.

The same thing should be done with tests.