### PR TITLE
Drop using docker as root

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before-install:
   - composer self-update
 
 install:
-  - make build
+  - composer install
 
 script:
   - make test

--- a/Makefile
+++ b/Makefile
@@ -12,4 +12,4 @@ test: ## Run tests
 	bin/behat
 
 run_local:  ## Run local environment
-	sudo docker-compose up -d
+	docker-compose up -d


### PR DESCRIPTION
Instread of enforcing other users to run docker as sudo, everybody should configure groups:
https://docs.docker.com/engine/installation/linux/linux-postinstall/

